### PR TITLE
Update arn regex

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -45,7 +45,7 @@ params:
       title: Create Database from Snapshot
       description: On **creation**, restores a database from snapshot.
       $ref: https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/aws-arn.json
-      pattern: "^arn:aws:[a-zA-Z0-9._-]*:[a-zA-Z0-9._-]*:[0-9]{12}:cluster-snapshot:[a-zA-Z0-9/._-]+$"
+      pattern: "^arn:aws:[a-zA-Z0-9._-]*:[a-zA-Z0-9._-]*:[0-9]{12}:cluster-snapshot:[a-zA-Z0-9/.:_-]+$"
     username:
       title: Username
       description: Administrative (root) DB username


### PR DESCRIPTION
Fixes issue with `cluster-snapshot:rds:infra` string

Validation:
![image](https://github.com/massdriver-cloud/aws-aurora-serverless-postgres/assets/8037512/ffec5fad-e34f-44aa-a287-fb5b46b7e414)
